### PR TITLE
Generate a APK with the DT dependencies already added

### DIFF
--- a/.github/workflows/gradle-publish.yml
+++ b/.github/workflows/gradle-publish.yml
@@ -66,16 +66,17 @@ jobs:
         run: |
           cd FtcRobotController
           ./gradlew assembleRelease
+          mv TeamCode/build/outputs/apk/release/TeamCode-release.apk TeamCode/build/outputs/apk/release/FtcRobotController-DTLibrary-${{ env.RELEASE_VERSION }}.apk
 
       - name: Upload APK
         uses: actions/upload-artifact@v4
         with:
           name: FtcRobotController-DTLibrary-${{ env.RELEASE_VERSION }}
-          path: FtcRobotController/FtcRobotController/build/outputs/apk/release/*.apk
+          path: TeamCode/build/outputs/apk/release/FtcRobotController-DTLibrary-${{ env.RELEASE_VERSION }}.apk
 
       - name: Upload APK to Release Page
         uses: softprops/action-gh-release@v2
         with:
-          files: FtcRobotController/FtcRobotController/build/outputs/apk/release/*.apk
+          files: TeamCode/build/outputs/apk/release/FtcRobotController-DTLibrary-${{ env.RELEASE_VERSION }}.apk
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/gradle-publish.yml
+++ b/.github/workflows/gradle-publish.yml
@@ -69,10 +69,8 @@ jobs:
         run: |
           cd FtcRobotController
           ./gradlew assembleRelease
-          mv TeamCode/build/outputs/apk/release/TeamCode-release.apk TeamCode/build/outputs/apk/release/FtcRobotController-DTLibrary-${{ env.RELEASE_VERSION }}.apk
           
-          cd TeamCode/build
-          ls --all --recursive
+          mv TeamCode/build/outputs/apk/release/TeamCode-release.apk TeamCode/build/outputs/apk/release/FtcRobotController-DTLibrary-${{ env.RELEASE_VERSION }}.apk
 
       - name: Upload APK
         uses: actions/upload-artifact@v4

--- a/.github/workflows/gradle-publish.yml
+++ b/.github/workflows/gradle-publish.yml
@@ -49,6 +49,9 @@ jobs:
           java-version: '21'
           distribution: 'corretto'
 
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4.3.1
+
       - name: Get release tag
         id: get_version
         run: echo "RELEASE_VERSION=${GITHUB_REF_NAME}" >> $GITHUB_ENV
@@ -67,16 +70,19 @@ jobs:
           cd FtcRobotController
           ./gradlew assembleRelease
           mv TeamCode/build/outputs/apk/release/TeamCode-release.apk TeamCode/build/outputs/apk/release/FtcRobotController-DTLibrary-${{ env.RELEASE_VERSION }}.apk
+          
+          cd TeamCode/build
+          ls --all --recursive
 
       - name: Upload APK
         uses: actions/upload-artifact@v4
         with:
           name: FtcRobotController-DTLibrary-${{ env.RELEASE_VERSION }}
-          path: TeamCode/build/outputs/apk/release/FtcRobotController-DTLibrary-${{ env.RELEASE_VERSION }}.apk
+          path: FtcRobotController/TeamCode/build/outputs/apk/release/FtcRobotController-DTLibrary-${{ env.RELEASE_VERSION }}.apk
 
       - name: Upload APK to Release Page
         uses: softprops/action-gh-release@v2
         with:
-          files: TeamCode/build/outputs/apk/release/FtcRobotController-DTLibrary-${{ env.RELEASE_VERSION }}.apk
+          files: FtcRobotController/TeamCode/build/outputs/apk/release/FtcRobotController-DTLibrary-${{ env.RELEASE_VERSION }}.apk
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/gradle-publish.yml
+++ b/.github/workflows/gradle-publish.yml
@@ -58,7 +58,7 @@ jobs:
           GRADLE_FILE="FtcRobotController/build.dependencies.gradle"
 
           sed -i '/repositories {/,/}/{s/}/    maven {\n        url "https:\/\/maven.megaknytes.org\/releases"\n    }\n}/}' $GRADLE_FILE
-          sed -i '/dependencies {/,/}/{s/}/    implementation "org.megaknytes.ftc.decisiontable:core:${{ env.RELEASE_VERSION }}"\n    implementation "org.megaknytes.ftc.decisiontable:editor:${{ env.RELEASE_VERSION }}"\n}/}' $GRADLE_FILE
+          sed -i '/dependencies {/,/}/{s/}/    implementation "org.megaknytes.ftc.decisiontable:Core:${{ env.RELEASE_VERSION }}"\n    implementation "org.megaknytes.ftc.decisiontable:Editor:${{ env.RELEASE_VERSION }}"\n}/}' $GRADLE_FILE
 
           cat $GRADLE_FILE
 

--- a/.github/workflows/gradle-publish.yml
+++ b/.github/workflows/gradle-publish.yml
@@ -2,15 +2,17 @@ name: Publishes MegaKnytes Gradle Packages to GitHub Packages
 on:
   workflow_dispatch:
   push:
+    branches:
+      - '**'
+    tags-ignore:
+      - '*'
   release:
     types: [created]
-
 jobs:
   publish:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      packages: write
     steps:
       - uses: actions/checkout@v4.2.2
 
@@ -28,3 +30,52 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           MEGAKNYTES_MAVEN_USERNAME: ${{ secrets.MEGAKNYTES_MAVEN_USERNAME }}
           MEGAKNYTES_MAVEN_PASSWORD: ${{ secrets.MEGAKNYTES_MAVEN_PASSWORD }}
+
+  apk-build:
+    if: github.event_name == 'release'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    needs: publish
+    steps:
+      - name: Checkout FtcRobotController repo
+        uses: actions/checkout@v4
+        with:
+          repository: FIRST-Tech-Challenge/FtcRobotController
+          path: FtcRobotController
+
+      - uses: actions/setup-java@v4.7.0
+        with:
+          java-version: '21'
+          distribution: 'corretto'
+
+      - name: Get release tag
+        id: get_version
+        run: echo "RELEASE_VERSION=${GITHUB_REF_NAME}" >> $GITHUB_ENV
+
+      - name: Add DecisionTable to build.dependencies.gradle
+        run: |
+          GRADLE_FILE="FtcRobotController/build.dependencies.gradle"
+
+          sed -i '/repositories {/,/}/{s/}/    maven {\n        url "https:\/\/maven.megaknytes.org\/releases"\n    }\n}/}' $GRADLE_FILE
+          sed -i '/dependencies {/,/}/{s/}/    implementation "org.megaknytes.ftc.decisiontable:core:${{ env.RELEASE_VERSION }}"\n    implementation "org.megaknytes.ftc.decisiontable:editor:${{ env.RELEASE_VERSION }}"\n}/}' $GRADLE_FILE
+
+          cat $GRADLE_FILE
+
+      - name: Build FtcRobotController APK
+        run: |
+          cd FtcRobotController
+          ./gradlew assembleRelease
+
+      - name: Upload APK
+        uses: actions/upload-artifact@v4
+        with:
+          name: FtcRobotController-DTLibrary-${{ env.RELEASE_VERSION }}
+          path: FtcRobotController/FtcRobotController/build/outputs/apk/release/*.apk
+
+      - name: Upload APK to Release Page
+        uses: softprops/action-gh-release@v2
+        with:
+          files: FtcRobotController/FtcRobotController/build/outputs/apk/release/*.apk
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Core/build.gradle
+++ b/Core/build.gradle
@@ -61,7 +61,7 @@ publishing {
         if (System.getenv("CI")) {
             referenceRelease(MavenPublication) {
                 groupId = 'org.megaknytes.ftc.decisiontable'
-                artifactId = 'core'
+                artifactId = 'Core'
 
                 version = System.getenv("GITHUB_REF_TYPE") == "tag" ? System.getenv("GITHUB_REF_NAME") : System.getenv("GITHUB_REF_NAME") + "-SNAPSHOT"
 
@@ -71,26 +71,10 @@ publishing {
                     from components.release
                 }
             }
-
-            if (System.getenv("GITHUB_REF_TYPE") != "tag") {
-                commitHashRelease(MavenPublication) {
-                    groupId = 'org.megaknytes.ftc.decisiontable'
-                    artifactId = 'core'
-
-                    version = System.getenv("GITHUB_SHA")?.substring(0, 7)
-
-                    configureBasePom(delegate)
-
-                    afterEvaluate {
-                        from components.release
-                    }
-                }
-            }
-
         } else {
-            baseRelease(MavenPublication) {
+            localRelease(MavenPublication) {
                 groupId = 'org.megaknytes.ftc.decisiontable'
-                artifactId = 'core'
+                artifactId = 'Core'
                 version = "localDeployment-SNAPSHOT"
 
                 configureBasePom(delegate)

--- a/Editor/build.gradle
+++ b/Editor/build.gradle
@@ -78,7 +78,7 @@ publishing {
         if (System.getenv("CI")) {
             referenceRelease(MavenPublication) {
                 groupId = 'org.megaknytes.ftc.decisiontable'
-                artifactId = 'editor'
+                artifactId = 'Editor'
 
                 version = System.getenv("GITHUB_REF_TYPE") == "tag" ? System.getenv("GITHUB_REF_NAME") : System.getenv("GITHUB_REF_NAME") + "-SNAPSHOT"
 
@@ -88,26 +88,10 @@ publishing {
                     from components.release
                 }
             }
-
-            if (System.getenv("GITHUB_REF_TYPE") != "tag") {
-                commitHashRelease(MavenPublication) {
-                    groupId = 'org.megaknytes.ftc.decisiontable'
-                    artifactId = 'editor'
-
-                    version = System.getenv("GITHUB_SHA")?.substring(0, 7)
-
-                    configureBasePom(delegate)
-
-                    afterEvaluate {
-                        from components.release
-                    }
-                }
-            }
-
         } else {
-            baseRelease(MavenPublication) {
+            localRelease(MavenPublication) {
                 groupId = 'org.megaknytes.ftc.decisiontable'
-                artifactId = 'editor'
+                artifactId = 'Editor'
                 version = "localDeployment-SNAPSHOT"
 
                 configureBasePom(delegate)


### PR DESCRIPTION
This pull request implements changes to the DT library build system to streamline the publishing process, reduce the number of builds, and make it easier for teams to integrate the DT library onto their robot. 

### GitHub Actions Workflow Enhancements:
* Updated `.github/workflows/gradle-publish.yml` to include a new `apk-build` job that triggers during releases. This job builds an APK for the `FtcRobotController` project, modifies its dependencies, and uploads the resulting APK to both the release page and as an artifact.
* Adjusted the `push` event in the workflow to include all branches and ignore tags, preventing two actions from being created at once on creation of a release

### Gradle Build Script Updates:
* Changed the artifact IDs in `Core/build.gradle` and `Editor/build.gradle` from lowercase (`core`, `editor`) to uppercase (`Core`, `Editor`) for consistency with Gradle naming conventions.
* Removed conditional logic for creating `commitHashRelease` publications in both `Core/build.gradle` and `Editor/build.gradle`, to simplify the publication process.